### PR TITLE
Remove document.readyState as pageIsLoaded criteria

### DIFF
--- a/src/turbolinks/history.coffee
+++ b/src/turbolinks/history.coffee
@@ -23,6 +23,14 @@ class Turbolinks.History
 
   # Event handlers
 
+  # Chrome < 34 and Safari < 10 dispatch an initial popstate event on page load.
+  # Ignore it by setting the pageLoaded after the page load is done (hence defer).
+  # Details: https://developer.mozilla.org/en/docs/Web/API/WindowEventHandlers/onpopstate
+
+  onPageLoad: (event) =>
+    Turbolinks.defer =>
+      @pageLoaded = true
+
   onPopState: (event) =>
     if @shouldHandlePopState()
       if turbolinks = event.state?.turbolinks
@@ -30,18 +38,13 @@ class Turbolinks.History
         restorationIdentifier = turbolinks.restorationIdentifier
         @delegate.historyPoppedToLocationWithRestorationIdentifier(location, restorationIdentifier)
 
-  onPageLoad: (event) =>
-    Turbolinks.defer =>
-      @pageLoaded = true
-
   # Private
 
   shouldHandlePopState: ->
-    # Safari dispatches a popstate event after window's load event, ignore it
     @pageIsLoaded()
 
   pageIsLoaded: ->
-    @pageLoaded or document.readyState is "complete"
+    @pageLoaded
 
   update: (method, location, restorationIdentifier) ->
     state = turbolinks: {restorationIdentifier}


### PR DESCRIPTION
As [described here](https://github.com/turbolinks/turbolinks/commit/e90e4c4ad94b35d9f3f0a90b6810aa65311175d5##commitcomment-23820789) the `document.readyState is "complete"` breaks back button functionality in Safari >= 10.